### PR TITLE
Use scality-s3server 7.4.4.10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     commands:
       - git clone https://github.com/scality/cloudserver.git scality-s3server
       - cd ./scality-s3server
-      - git checkout 7.4.0.1
+      - git checkout 7.4.4.10
   override-entrypoint-script:
     image: owncloud/ubuntu
     pull: true


### PR DESCRIPTION
As it should be better than 7.4.0.1
Trying to reduce the occurrence of crash on startup issue https://github.com/owncloud/core/issues/36398

https://github.com/scality/cloudserver/releases/tag/7.4.4.10

(note: there is also 7.5.0.1 available, released recently. But it probably we can stick with the latest 7.4 series.)